### PR TITLE
Enable one-click deployment to Github

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: Deploy to GitHub Pages
+
+# Auto-deploys index.html and its assets to GitHub Pages every time main
+# is updated. After this workflow runs successfully once, the live site is at
+# https://<owner>.github.io/<repo>/ and any push refreshes it within ~1 minute.
+#
+# One-time setup (only needed once, by a repo admin):
+#   Repo Settings -> Pages -> Source -> "GitHub Actions"
+# That's it. From then on, every push to main republishes automatically.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Cancel an in-flight deploy if a newer one starts. Don't kill a deploy
+# that's already mid-flight just because someone pushed twice.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 
 **Identify any plant from a photo. Then find every record of it sitting in the world's herbaria.**
 
+### ▶ [Launch the app](https://theoryofshadows.github.io/specimen-finder/)
+
+Once deployed, the live tool runs in your browser at the link above. No install. No account. No mock data. The "Search by name" tab works immediately; photo ID needs a free Pl@ntNet key (~2 min).
+
+> **First-time setup (one click, repo owner only).** GitHub Pages needs to be enabled once. Go to **Settings → Pages**, set **Source** to **GitHub Actions**, save. The included workflow (`.github/workflows/pages.yml`) will then redeploy automatically on every push to `main`. Live URL: `https://theoryofshadows.github.io/specimen-finder/`.
+
+---
+
 Specimen Finder is a single-page web tool that ties together open botanical data — Pl@ntNet for photo identification, GBIF for specimen records aggregated from 1,800+ herbaria, plus Wikipedia, Wikidata, POWO, and iNaturalist for context — and then flags which of those specimens look unusual: wrong location, wrong era, missing coordinates, or possible label errors.
 
-It is built for botanists, herbarium curators, conservation biologists, students, naturalists, and curious people. No accounts. No tracking. No mock data. No server. Open it in a browser and use it.
+It is built for botanists, herbarium curators, conservation biologists, students, naturalists, and curious people. No accounts. No tracking. No mock data. No server.
 
 ---
 
@@ -22,26 +30,23 @@ No single curator can audit the global pool. So errors accumulate, and important
 
 ## How to use it
 
-### Option A — open `index.html` directly
+The fastest path: open **[the live app](https://theoryofshadows.github.io/specimen-finder/)** and search for a plant. Common names like "swamp milkweed" or scientific names like *Sarracenia purpurea* both work, and you can share a result by copying the URL — every search updates the address bar (`?q=Species+name`).
 
-Download or clone, then double-click `index.html`. The "Search by name" tab works immediately. (Photo identification needs to be served over HTTP because of how the Pl@ntNet API handles browser requests — see Option B.)
+### Run your own copy
 
-### Option B — host as a static page (recommended)
+- **GitHub Pages (recommended).** Fork this repo, flip Settings → Pages → Source to "GitHub Actions" once, and every commit auto-deploys. The included workflow handles it.
+- **Local dev.** `python3 -m http.server 8000` from the repo root, then open `http://localhost:8000`.
+- **Other static hosts.** Netlify / Vercel / Cloudflare Pages — drag-and-drop the repo or connect it. The site is plain HTML/JS, no build step.
+- **Direct file open.** Double-clicking `index.html` works for "Search by name." Photo identification needs HTTPS or localhost because of CORS.
 
-Deploy `index.html` anywhere that serves static files:
+### Photo identification (optional)
 
-- **GitHub Pages**: in the repo Settings → Pages, set Source to your branch and root. The site will be at `https://<user>.github.io/specimen-finder/`.
-- **Netlify / Vercel / Cloudflare Pages**: drag-and-drop `index.html` or connect the repo.
-- **Any static host**: `python3 -m http.server 8000` from this directory, then open `http://localhost:8000`.
-
-### Option C — search by photo
-
-To use photo identification, get a free Pl@ntNet API key (~2 minutes):
+To search by photo, get a free Pl@ntNet API key (~2 minutes):
 
 1. Sign up at [my.plantnet.org](https://my.plantnet.org/)
 2. Verify your email and log in
 3. Account → "API key" → copy
-4. In Specimen Finder, click "Set up photo ID" and paste
+4. In the app, click "Set up photo ID" and paste
 
 Free tier allows 500 identifications per day. The key is stored in your browser's `localStorage` only — never transmitted anywhere except directly to Pl@ntNet.
 


### PR DESCRIPTION
- Adds .github/workflows/pages.yml so every push to main auto-deploys the site to GitHub Pages using the official actions/deploy-pages flow.
- Reworks the README so the very first thing a visitor sees is a giant "Launch the app" link, the one-time Pages setup step, and a path to fork-and-deploy.
- The repo owner only needs to flip Settings -> Pages -> Source -> "GitHub Actions" once. After that, every commit publishes to https://theoryofshadows.github.io/specimen-finder/ within ~1 minute.